### PR TITLE
feat: add POST /todos endpoint

### DIFF
--- a/src/middleware/validate.js
+++ b/src/middleware/validate.js
@@ -1,0 +1,9 @@
+function requireTitle(req, res, next) {
+  const { title } = req.body;
+  if (!title || typeof title !== 'string' || title.trim() === '') {
+    return res.status(400).json({ error: 'title is required and must be a non-empty string' });
+  }
+  next();
+}
+
+module.exports = { requireTitle };

--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const store = require('../store');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json(store.getAll());
+});
+
+router.get('/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const todo = store.getById(id);
+  if (!todo) {
+    return res.status(404).json({ error: 'Todo not found' });
+  }
+  res.json(todo);
+});
+
+router.post('/', (req, res) => {
+  const { title, completed } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'title is required' });
+  }
+  const todo = store.create({ title, completed });
+  res.status(201).json(todo);
+});
+
+module.exports = router;

--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const store = require('../store');
+const { requireTitle } = require('../middleware/validate');
 
 const router = express.Router();
 
@@ -16,11 +17,8 @@ router.get('/:id', (req, res) => {
   res.json(todo);
 });
 
-router.post('/', (req, res) => {
+router.post('/', requireTitle, (req, res) => {
   const { title, completed } = req.body;
-  if (!title) {
-    return res.status(400).json({ error: 'title is required' });
-  }
   const todo = store.create({ title, completed });
   res.status(201).json(todo);
 });


### PR DESCRIPTION
## Summary

- Adds `POST /todos` route to `src/routes/todos.js`
- Creates a new todo with `title` (required) and optional `completed` fields
- Returns `201` with the created todo object
- Returns `400` if `title` is missing

## Test plan

- [ ] `POST /todos` with `{ "title": "Buy milk" }` returns `201` and `{ id: 1, title: "Buy milk", completed: false }`
- [ ] `POST /todos` with `{ "title": "Buy milk", "completed": true }` returns `201` with `completed: true`
- [ ] `POST /todos` without `title` returns `400` with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)